### PR TITLE
Update docker ppc64le kickstart file

### DIFF
--- a/docker/centos-7ppc64le.ks
+++ b/docker/centos-7ppc64le.ks
@@ -18,7 +18,7 @@ timezone --isUtc --nontp UTC
 selinux --enforcing
 firewall --disabled
 network --bootproto=dhcp --device=link --activate --onboot=on
-reboot
+shutdown
 bootloader --disable
 lang en_US
 
@@ -43,8 +43,10 @@ centos-release
 less
 -kernel*
 -*firmware
+-firewalld-filesystem
 -os-prober
 -gettext*
+-GeoIP
 -bind-license
 -freetype
 iputils
@@ -74,7 +76,7 @@ yum -y remove bind-libs bind-libs-lite dhclient dhcp-common dhcp-libs \
   grubby initscripts iproute iptables kexec-tools libcroco libgomp \
   libmnl libnetfilter_conntrack libnfnetlink libselinux-python lzo \
   libunistring os-prober python-decorator python-slip python-slip-dbus \
-  snappy sysvinit-tools which linux-firmware
+  snappy sysvinit-tools which linux-firmware GeoIP firewalld-filesystem
 
 yum clean all
 
@@ -82,41 +84,37 @@ yum clean all
 rm -rf /boot
 rm -rf /etc/firewalld
 
-# Randomize root's password and lock
-dd if=/dev/urandom count=50 | md5sum | passwd --stdin root
+# Lock roots account, keep roots account password-less.
 passwd -l root
 
 #LANG="en_US"
 #echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 
-awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=1}{print}' \
+awk '(NF==0&&!done){print "override_install_langs=en_US.utf8\ntsflags=nodocs";done=1}{print}' \
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
 
-rm -f /usr/lib/locale/locale-archive
-
-#Setup locale properly
-localedef -v -c -i en_US -f UTF-8 en_US.UTF-8
-
+## Remove some things we don't need
 rm -rf /var/cache/yum/*
-rm -f /tmp/ks-script*
 rm -rf /var/log/*
 rm -rf /tmp/*
 rm -rf /etc/sysconfig/network-scripts/ifcfg-*
+# do we really need a hardware database in a container?
+rm -rf /etc/udev/hwdb.bin
+rm -rf /usr/lib/udev/hwdb.d/*
 
+## Systemd fixes
+# no machine-id by default.
+:> /etc/machine-id
 # Fix /run/lock breakage since it's not tmpfs in docker
 umount /run
 systemd-tmpfiles --create --boot
 # Make sure login works
 rm /var/run/nologin
 
-
 #Generate installtime file record
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
-
-
-:> /etc/machine-id
 
 
 %end


### PR DESCRIPTION
This updates the ppc64le kickstart file to be closer to the ones used
for x86 and aarch64.

Fixes the locale issue from
https://github.com/CentOS/sig-cloud-instance-images/issues/86